### PR TITLE
Python 3.10 quick fixup

### DIFF
--- a/eventdispatcher/dictproperty.py
+++ b/eventdispatcher/dictproperty.py
@@ -1,5 +1,6 @@
 __author__ = 'calvin'
 import collections
+import collections.abc
 from future.utils import iteritems, iterkeys, itervalues
 from functools import partial
 from . import Property

--- a/eventdispatcher/dictproperty.py
+++ b/eventdispatcher/dictproperty.py
@@ -11,7 +11,7 @@ class __DoesNotExist__:
     pass
 
 
-class ObservableDict(collections.MutableMapping):
+class ObservableDict(collections.abc.MutableMapping):
 
     def __init__(self, dictionary, dispatch_method):
         self.dictionary = dictionary.copy()

--- a/eventdispatcher/listproperty.py
+++ b/eventdispatcher/listproperty.py
@@ -1,6 +1,7 @@
 __author__ = 'calvin'
 
 import collections
+import collections.abc
 from functools import partial
 from copy import copy
 import numpy as np

--- a/eventdispatcher/listproperty.py
+++ b/eventdispatcher/listproperty.py
@@ -9,7 +9,7 @@ import numpy as np
 from . import Property
 
 
-class ObservableList(collections.MutableSequence):
+class ObservableList(collections.abc.MutableSequence):
     def __init__(self, l, dispatch_method, dtype=None):
         if not type(l) == list and not type(l) == tuple and not isinstance(l, ObservableList):
             raise ValueError('Observable list must only be initialized with sequences as arguments')

--- a/eventdispatcher/setproperty.py
+++ b/eventdispatcher/setproperty.py
@@ -1,5 +1,6 @@
 __author__ = 'calvin'
 import collections
+import collections.abc
 from functools import partial
 from . import Property
 

--- a/eventdispatcher/setproperty.py
+++ b/eventdispatcher/setproperty.py
@@ -5,7 +5,7 @@ from functools import partial
 from . import Property
 
 
-class ObservableSet(collections.MutableSet):
+class ObservableSet(collections.abc.MutableSet):
 
     def __init__(self, dictionary, dispatch_method):
         self.set = dictionary.copy()


### PR DESCRIPTION
This allows projects using eventdispatcher to function after the py3 migration of some objects to the collections.abc abstract class.